### PR TITLE
stop passing on user-supplied error handler

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -322,8 +322,6 @@ class FastAPIInstrumentor(BaseInstrumentor):
                 ):  # usually true
                     outer_server_error_middleware = ServerErrorMiddleware(
                         app=otel_middleware,
-                        handler=inner_server_error_middleware.handler,
-                        debug=inner_server_error_middleware.debug,
                     )
                 else:
                     # Something else seems to have patched things, or maybe Starlette changed.


### PR DESCRIPTION
This prevents potential side effects, such as logging, to be executed more than once per request handler exception.